### PR TITLE
Papers: Add "Awards" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ assume them to be empty otherwise), while the other fields (`venue`, `year`,
 
 - `title`: Title of your paper. Will be used as header of the block.
 - `authors`: List of authors.
+- `awards` (optional, string or list of string): Award(s) that your paper may
+  have received.
 - `venue` (optional): Journal or conference.
 - `year` (optional): Date of the conference, if present it is going to be in
   parentheses after the venue (unless the venue is absent in which case it

--- a/pandoc/paper.lua
+++ b/pandoc/paper.lua
@@ -8,6 +8,7 @@ function jsondata(data)
   newdata.venue = data.venue
   newdata.year = data.year
   newdata.files = data.files or pandoc.List()
+  newdata.awards = data.awards or pandoc.List()
 
   return newdata
 
@@ -38,6 +39,15 @@ function yamldata(data)
     return newfile
   end)
 
+  local awards = data["awards"] or pandoc.List()
+  if pandoc.utils.type(awards) == 'List' then
+    newdata.awards = awards:map(function(data)
+      return pandoc.utils.stringify(data)
+    end)
+  else
+    newdata.awards = pandoc.utils.stringify(awards)
+  end
+
   return newdata
 
 end
@@ -47,6 +57,7 @@ function paper(data)
   local title = data.title
   local url = data.url
   local authors = data.authors
+  local awards = data.awards
   local venue = data.venue
   local year = data.year
   local files = data.files
@@ -57,6 +68,22 @@ function paper(data)
     header = { pandoc.Link(title, url) }
   else
     header = { title }
+  end
+
+  local award_info = {}
+  if awards then
+    if not (pandoc.utils.type(awards) == 'List') then
+      awards = pandoc.List({awards})
+    end
+    award_info = awards:map(function(awd)
+      local icon = "<i class=\" fa-solid fa-award\"></i>"
+
+      local html_output = string.format(
+        "<span>%s %s</span>",
+          icon, awd
+      )
+      return pandoc.RawBlock("html", html_output)
+    end)
   end
 
   local sub = {}
@@ -110,6 +137,7 @@ function paper(data)
 
   local div_content = {
     pandoc.Header(3, header),
+    pandoc.Div(award_info, {class = "awards"}),
     pandoc.Div(authors, {class = "authors"}),
     pandoc.Para(sub),
     pandoc.Div(file_info, {class = "files"})

--- a/src/index.md
+++ b/src/index.md
@@ -52,6 +52,7 @@ My workflow is usually to use <kbd>Ctrl</kbd> + <kbd>C</kbd> /
 ``` json {.paper}
 "title": "Towards automatic academic pages",
 "authors": "Templato Urnehm, U. N. Owen",
+"awards": "Automatic Award",
 "venue": "Principles of Awesomeness (PAW)",
 "year": "2023",
 "url": "https://basicpage.github.io",
@@ -67,6 +68,9 @@ My workflow is usually to use <kbd>Ctrl</kbd> + <kbd>C</kbd> /
 ``` yaml {.paper}
 title: Yet another yaml parser 3
 authors: Templato Urnehm
+awards: 
+  - Yet another "Yet another" award
+  - Never-ending Work Award
 venue: Proceedings of Nihilism
 year: 2029
 url: https://basicpage.github.io
@@ -94,6 +98,7 @@ papers:
         src: foo.bib
   - title: Yet another yaml parser
     authors: Templato Urnehm
+    awards: Yet another "Yet another" award
     venue: Proceedings of Nihilism
     year: 2025
     files:
@@ -123,6 +128,10 @@ papers:
 ``` json {.paper}
 "title": "TBD",
 "authors": "TBD",
+"awards": [
+  "Best Draft Award",
+  "Test-of-time Award for works which just never leave the draft stage"
+],
 "files": [
   { "text": "🐱 video", "type": "video", "src": "foo.mov" },
   { "text": "Poem", "type": "txt", "src": "foo.txt" },

--- a/website/style.css
+++ b/website/style.css
@@ -335,6 +335,23 @@ div.files a:hover {
   text-decoration: none;
 }
 
+div.awards {
+  display: flex;
+  justify-content: flex-start;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 5px 0;
+}
+
+div.awards span {
+  border-radius: 5px;
+  padding: 4px;
+  margin-right: 5px;
+  background: #F6ECD0;
+  color: #CF9C11;
+}
+
 span.lastupdate {
   color: #9e9d9d;
 }


### PR DESCRIPTION
Adds an `awards` field to the YAML and JSON paper formats.
Supports both single strings or lists of strings (see `src/index.md` for examples).